### PR TITLE
Dynamically setting/adding child objects

### DIFF
--- a/Example/Modelmatic/Author.swift
+++ b/Example/Modelmatic/Author.swift
@@ -11,7 +11,7 @@ class Author: ModelObject
 {
     static let entityName = "Author"
     
-    var externalID: NSNumber!
+    var externalID: NSNumber?
     var firstName: String?
     var lastName: String?
     var dateOfBirth: NSDate?

--- a/Example/Modelmatic/Authors.xcdatamodeld/.xccurrentversion
+++ b/Example/Modelmatic/Authors.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>Authors 2.xcdatamodel</string>
+	<string>Authors 3.xcdatamodel</string>
 </dict>
 </plist>

--- a/Example/Modelmatic/Authors.xcdatamodeld/Authors 3.xcdatamodel/contents
+++ b/Example/Modelmatic/Authors.xcdatamodeld/Authors 3.xcdatamodel/contents
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="10174" systemVersion="15F34" minimumToolsVersion="Xcode 7.0">
+    <entity name="Author" representedClassName="MDLAuthor" syncable="YES">
+        <attribute name="dateOfBirth" optional="YES" attributeType="Transformable" valueTransformerName="Date" syncable="YES">
+            <userInfo>
+                <entry key="externalKeyPath" value="born"/>
+            </userInfo>
+        </attribute>
+        <attribute name="externalID" optional="YES" attributeType="Integer 16" defaultValueString="0" syncable="YES">
+            <userInfo>
+                <entry key="externalKeyPath" value="author_id"/>
+            </userInfo>
+        </attribute>
+        <attribute name="firstName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="imageURL" optional="YES" attributeType="String" valueTransformerName="" syncable="YES"/>
+        <attribute name="lastName" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="books" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Book" inverseName="author" inverseEntity="Book" syncable="YES"/>
+    </entity>
+    <entity name="Book" representedClassName="MDLBook" syncable="YES">
+        <attribute name="externalID" optional="YES" attributeType="Integer 16" defaultValueString="0" syncable="YES">
+            <userInfo>
+                <entry key="externalKeyPath" value="book_id"/>
+            </userInfo>
+        </attribute>
+        <attribute name="favorite" optional="YES" attributeType="Boolean" valueTransformerName="CDXBoolean" syncable="YES"/>
+        <attribute name="rating" optional="YES" attributeType="Integer 32" defaultValueString="0" syncable="YES"/>
+        <attribute name="tags" optional="YES" attributeType="Transformable" valueTransformerName="StringArray" syncable="YES"/>
+        <attribute name="title" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="year" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="author" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Author" inverseName="books" inverseEntity="Author" syncable="YES"/>
+        <relationship name="pricing" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Pricing" inverseName="book" inverseEntity="Pricing" syncable="YES"/>
+        <userInfo>
+            <entry key="externalKeyPath" value="book_id"/>
+        </userInfo>
+    </entity>
+    <entity name="Pricing" representedClassName="MDLPricing" syncable="YES">
+        <attribute name="discountedPrice" optional="YES" attributeType="Double" defaultValueString="0.0" syncable="YES"/>
+        <attribute name="externalID" optional="YES" attributeType="Integer 16" defaultValueString="0" syncable="YES">
+            <userInfo>
+                <entry key="externalID" value="pricing_id"/>
+            </userInfo>
+        </attribute>
+        <attribute name="retailPrice" optional="YES" attributeType="Double" defaultValueString="0.0" syncable="YES"/>
+        <relationship name="book" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Book" inverseName="pricing" inverseEntity="Book" syncable="YES"/>
+    </entity>
+    <elements>
+        <element name="Author" positionX="-468" positionY="-81" width="128" height="133"/>
+        <element name="Book" positionX="-252" positionY="-96" width="128" height="163"/>
+        <element name="Pricing" positionX="-63" positionY="-36" width="128" height="103"/>
+    </elements>
+</model>

--- a/Example/Modelmatic/Book.swift
+++ b/Example/Modelmatic/Book.swift
@@ -11,13 +11,17 @@ class Book: ModelObject
 {
     static let entityName = "Book"
     
-    var externalID: NSNumber!
+    var externalID: NSNumber?
     var title: String!
     var year: String?
     var tags: [String]?
     var favorite: Bool?
     var rating: Int?
     
+    // Reference to child object in one-to-one relationship
+    var pricing: Pricing?
+    
+    // Reference to parent object in one-to-many relationship
     // IMPORTANT: Use weak reference when modeling inverse relationship.
     weak var author: Author?
     

--- a/Example/Modelmatic/Pricing.swift
+++ b/Example/Modelmatic/Pricing.swift
@@ -1,0 +1,41 @@
+//
+//  Pricing.swift
+//  Modelmatic
+//
+//  Created by Jonathan Lehr on 8/26/16.
+//  Copyright © 2016 CocoaPods. All rights reserved.
+//
+
+import Foundation
+
+import Modelmatic
+
+@objc (MDLPricing)
+class Pricing: ModelObject
+{
+    static let entityName = "Pricing"
+    
+    var externalID: NSNumber!
+    var retailPrice: Double?
+    var discountedPrice: Double?
+    
+    // IMPORTANT: Use weak reference when modeling inverse relationship.
+    weak var book: Book?
+    
+    override  var description: String {
+        return "\(super.description) retail: \(retailPrice); discounted price: \(discountedPrice))"
+    }
+}
+
+extension Pricing
+{
+    var kvc_retailPrice: Double {
+        get { return retailPrice ?? 0.0 }
+        set { retailPrice = Optional(newValue) }
+    }
+
+    var kvc_discountedPrice: Double {
+        get { return discountedPrice ?? 0.0 }
+        set { discountedPrice = Optional(newValue) }
+    }
+}

--- a/Example/modelmatic.xcodeproj/project.pbxproj
+++ b/Example/modelmatic.xcodeproj/project.pbxproj
@@ -19,6 +19,8 @@
 		AB39E5341D58EE0B00CC2F30 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AB39E5311D58EE0B00CC2F30 /* Main.storyboard */; };
 		AB39E5351D58EE0B00CC2F30 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AB39E5321D58EE0B00CC2F30 /* LaunchScreen.storyboard */; };
 		AB39E5361D58EE0B00CC2F30 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AB39E5321D58EE0B00CC2F30 /* LaunchScreen.storyboard */; };
+		AB4FF3AC1D70A8E90040AFF2 /* Pricing.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB4FF3AB1D70A8E90040AFF2 /* Pricing.swift */; };
+		AB4FF3AD1D70B1030040AFF2 /* Authors.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = AB39E5261D58E74A00CC2F30 /* Authors.xcdatamodeld */; };
 		AB9D7EBB1D57CD95005B8A26 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB9D7EB31D57CD95005B8A26 /* AppDelegate.swift */; };
 		AB9D7EBC1D57CD95005B8A26 /* AuthorObjectStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB9D7EB41D57CD95005B8A26 /* AuthorObjectStore.swift */; };
 		AB9D7EBD1D57CD95005B8A26 /* AuthorDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB9D7EB51D57CD95005B8A26 /* AuthorDataSource.swift */; };
@@ -67,6 +69,8 @@
 		AB39E52E1D58ED9600CC2F30 /* EditBookController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EditBookController.swift; sourceTree = "<group>"; };
 		AB39E5311D58EE0B00CC2F30 /* Main.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Main.storyboard; sourceTree = "<group>"; };
 		AB39E5321D58EE0B00CC2F30 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
+		AB4FF3AA1D70A7920040AFF2 /* Authors 3.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Authors 3.xcdatamodel"; sourceTree = "<group>"; };
+		AB4FF3AB1D70A8E90040AFF2 /* Pricing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Pricing.swift; sourceTree = "<group>"; };
 		AB9D7EB31D57CD95005B8A26 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		AB9D7EB41D57CD95005B8A26 /* AuthorObjectStore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthorObjectStore.swift; sourceTree = "<group>"; };
 		AB9D7EB51D57CD95005B8A26 /* AuthorDataSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthorDataSource.swift; sourceTree = "<group>"; };
@@ -219,6 +223,7 @@
 			children = (
 				AB9D7EC41D57CE43005B8A26 /* Book.swift */,
 				AB9D7EC51D57CE43005B8A26 /* Author.swift */,
+				AB4FF3AB1D70A8E90040AFF2 /* Pricing.swift */,
 			);
 			name = "Model Classes";
 			sourceTree = "<group>";
@@ -435,6 +440,7 @@
 				AB9D7EC11D57CD95005B8A26 /* UIImage+ModelmaticAdditions.swift in Sources */,
 				AB9D7ED51D57D5A0005B8A26 /* StringArrayTransformer.swift in Sources */,
 				AB9D7EC01D57CD95005B8A26 /* BookCell.swift in Sources */,
+				AB4FF3AC1D70A8E90040AFF2 /* Pricing.swift in Sources */,
 				AB9D7EC71D57CE43005B8A26 /* Author.swift in Sources */,
 				AB9D7EBB1D57CD95005B8A26 /* AppDelegate.swift in Sources */,
 				ABD5ADE91D5B42CA008C69C5 /* NSURL+ModelmaticAdditions.swift in Sources */,
@@ -453,6 +459,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AB4FF3AD1D70B1030040AFF2 /* Authors.xcdatamodeld in Sources */,
 				ABD1A1751D6E28F7008552F9 /* ModelTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -649,10 +656,11 @@
 		AB39E5261D58E74A00CC2F30 /* Authors.xcdatamodeld */ = {
 			isa = XCVersionGroup;
 			children = (
+				AB4FF3AA1D70A7920040AFF2 /* Authors 3.xcdatamodel */,
 				AB39E5271D58E74A00CC2F30 /* Authors 2.xcdatamodel */,
 				AB39E5281D58E74A00CC2F30 /* Authors.xcdatamodel */,
 			);
-			currentVersion = AB39E5271D58E74A00CC2F30 /* Authors 2.xcdatamodel */;
+			currentVersion = AB4FF3AA1D70A7920040AFF2 /* Authors 3.xcdatamodel */;
 			path = Authors.xcdatamodeld;
 			sourceTree = "<group>";
 			versionGroupType = wrapper.xcdatamodel;

--- a/Modelmatic.podspec
+++ b/Modelmatic.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name             = 'Modelmatic'
-    s.version          = '0.4.2'
+    s.version          = '0.4.3'
     s.summary          = 'JSON serialization and deserialization for Swift model objects.'
     s.description      = <<-DESC
     Modelmatic adds JSON serialization and deserialization behavior to Swift model objects so that you don't have to. It allows you to take advantage of Xcode's built-in Core Data modeling tool to define mappings between object properties and JSON attributes, allowing you to seamlessly model relationships.

--- a/Modelmatic/Classes/Extensions.swift
+++ b/Modelmatic/Classes/Extensions.swift
@@ -9,7 +9,7 @@ public typealias JsonDictionary = [String: AnyObject]
 
 extension NSPropertyDescription
 {
-    public var externalKeyPath: String {
+    public var keyPath: String {
         return userInfo?["externalKeyPath"] as? String ?? name
     }
 }


### PR DESCRIPTION
Added methods to ModelObject for dynamically setting/adding children that also set parent references for any inverse relationships defined in the model.
